### PR TITLE
fix(phoenix-live-dashboard): remove trailing slash causing 404

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -100,7 +100,7 @@
 	branch = master
 [submodule "apps/phoenix-live-dashboard"]
 	path = apps/phoenix-live-dashboard
-	url = https://github.com/phoenixframework/phoenix_live_dashboard/
+	url = https://github.com/phoenixframework/phoenix_live_dashboard
 	branch = master
 [submodule "apps/liveview-counter-tutorial"]
 	path = apps/liveview-counter-tutorial


### PR DESCRIPTION
The trailing slash caused the following for me:
```
ERROR: Repository not found.
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
```